### PR TITLE
bump cmake min version to 3.10 for cmake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(splitcode)
 


### PR DESCRIPTION
cmake 4 dropped support for compatibility with cmake older than 3.5. the new stable min_version is 3.10
see https://cmake.org/cmake/help/latest/release/4.0.html